### PR TITLE
Allow the using of `format` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,20 @@ The above `<Lorem />` tag by default renders five paragraphs of lorem wrapped in
 
 You can pass the following props to the `Lorem` component to fine-tune the output.
 
-Prop                | Default            | Description      
+Prop                | Default            | Description
 ------------------- |:------------------:| ------------
-mode                | "paragraphs"       | if set to `"list"`, instead of `<p>` tags wrapped in a `<div>` it renders `<li>`s wrapped in an `<ul>`
-ordered             | false              | if `mode` is set to `"list"` and this prop has a truthy value, the list items are wrapped in an `<ol>` tag 
+mode                | 'paragraphs'       | if set to `'list'`, instead of `<p>` tags wrapped in a `<div>` it renders `<li>`s wrapped in an `<ul>`
+ordered             | false              | if `mode` is set to `'list'` and this prop has a truthy value, the list items are wrapped in an `<ol>` tag
 seed                | 0                  | the seed of the random number generator used for generating lorem text; changing this to a different natural number generates a different text
 count               | 5                  | number of paragraphs to generate
 sentenceLowerBound  | 5                  | minimum words per sentence
 sentenceUpperBound  | 15                 | maximum words per sentence
 paragraphLowerBound | 3                  | minimum sentences per paragraph
 paragraphUpperBound | 7                  | maximum sentences per paragraph
+format              | 'html'             | plain text or html
 words               | ['ad','dolor',...] | custom word dictionary
 
-The last six properties are send directly to the [lorem-ipsum][3] node module which is used internally to generate the lorem text.
+The last seven properties are send directly to the [lorem-ipsum][3] node module which is used internally to generate the lorem text.
 
 Other properties you pass (eg. `className`) are transferred to the wrapping tag.
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var Lorem = React.createClass({
   getDefaultProps: function() {
     return {
       mode:     'paragraphs',
+      format:   'html',
       count:    5,
       seed:     0,
       ordered:  false
@@ -20,7 +21,6 @@ var Lorem = React.createClass({
   render: function() {
     var props = extend({}, this.props, {
       units:  'paragraphs',
-      format: 'html',
       random: random
     });
 


### PR DESCRIPTION
For getting plain lorem text, without tags.